### PR TITLE
ID-6365: Removed France from eIDAS selector TEST (INTERNAL-COMMIT)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -4,3 +4,8 @@ CVE-2025-61728 # stdlib golang archive/zip
 CVE-2025-68121 # stdlib
 CVE-2026-29062 # jackson-core
 GHSA-72hv-8253-57qq # jackson-core
+CVE-2026-34483 # tomcat-embed-core
+CVE-2026-34487 # tomcat-embed-core
+CVE-2026-40477 # thymeleaf-spring6/thymeleaf
+CVE-2026-40478 # thymeleaf-spring6/thymeleaf
+GHSA-2m67-wjpj-xhg9 # jackson-core

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -27,7 +27,6 @@ eidas:
       - ES
       - EU
       - FI
-      - FR
       - HR
       - HU
       - IE
@@ -43,8 +42,8 @@ eidas:
       - PT
       - RO
       - SE
-      - SK
       - SI
+      - SK
     test: true
   eu-connector:
     redirect-uri: https://connector.test.eidasnode.no/SpecificConnectorRequest


### PR DESCRIPTION
SAK:
ID-6363

Sjekklister:  
Eigar:

- [ ] Vurdert Manual deploy
- [x] Vurdert "internal"
- [ ] Avhengigheter til andre saker avklart
- [ ] Har kjørt opp lokalt med docker-compose
- [ ] Oppdatering/oppretting av regresjonstester er avklart/utført
- [ ] Har oppdatert dependabots
- [ ] Har trimmet .trivyignore

Kodeles:

- [ ] Lesbar kode, nødvendige kommentarer
- [ ] Sak er godt nok forklart/dokumentert
- [ ] Løyser saka
- [ ] Risikovurdering ok
- [ ] Nødvendige unit-tester er på plass
- [ ] Nødvendige regresjonstester er oppdatert/oppretta/planlagt
- [ ] Har oppdatert readme (evt digdir docs om nødvendig)