### PR TITLE
ID-6422: Updated landcode selektor FR, IS and typo (INTERNAL-COMMIT)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,1 +1,2 @@
 #trivyignore file for ignoring specific vulnerabilities in the project
+CVE-2026-42579 # io.netty:netty-codec-dns fixed in 4.2.13.Final, 4.1.133.Final

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -27,6 +27,7 @@ eidas:
       - ES
       - EU
       - FI
+      - FR
       - HR
       - HU
       - IE

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -65,7 +65,6 @@ eidas:
     included:
       - AT
       - BE
-      - BE
       - BG
       - CY
       - CZ
@@ -78,7 +77,6 @@ eidas:
       - FI
       - FR
       - HR
-      - IS
       - IT
       - IT
       - LI


### PR DESCRIPTION
SAK:
ID-6422

Sjekklister:  
Eigar:

- [x] Vurdert Manual deploy
- [x] Vurdert "internal"
- [x] Avhengigheter til andre saker avklart
- [ ] Har kjørt opp lokalt med docker-compose
- [x] Oppdatering/oppretting av regresjonstester er avklart/utført
- [x] Har oppdatert dependabots
- [ ] Har trimmet .trivyignore

Kodeles:

- [x] Lesbar kode, nødvendige kommentarer
- [x] Sak er godt nok forklart/dokumentert
- [x] Løyser saka
- [x] Risikovurdering ok
- [x] Nødvendige unit-tester er på plass
- [x] Nødvendige regresjonstester er oppdatert/oppretta/planlagt
- [x] Har oppdatert readme (evt digdir docs om nødvendig)